### PR TITLE
fix: update deprecated docs link to docs.ebanx.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> ⚠️ **DEPRECATED** — This repository is no longer maintained. Please refer to the [official EBANX documentation](https://www.ebanx.com/business/en/developers) for up-to-date integration options.
+> ⚠️ **DEPRECATED** — This repository is no longer maintained. Please refer to the [official EBANX documentation](https://docs.ebanx.com/) for up-to-date integration options.
 
 # EBANX payment gateway for VirtueMart/Joomla
 

--- a/ebanx.php
+++ b/ebanx.php
@@ -2,7 +2,7 @@
 
 /**
  * @deprecated This plugin is deprecated and no longer maintained.
- *             See https://www.ebanx.com/business/en/developers for up-to-date integration options.
+ *             See https://docs.ebanx.com/ for up-to-date integration options.
  */
 
 /**


### PR DESCRIPTION
## Summary

Fixes the documentation link added in the deprecation notice — the previous URL was broken.

**Before:** `https://www.ebanx.com/business/en/developers`
**After:** `https://docs.ebanx.com/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)